### PR TITLE
fix: fix channel points comparison

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -494,8 +494,8 @@ def callback_channel_points(
     log.debug(data)
 
     if (
-        data["data"]["redemption"]["reward"]["title"].lower()
-        == config["CHANNEL_POINTS_REWARD"].lower()
+        str(data["data"]["redemption"]["reward"]["cost"])
+        == config["CHANNEL_POINTS_REWARD"]
     ):
         message: str = data["data"]["redemption"]["user_input"]
 


### PR DESCRIPTION
`callback_channel_points` was comparing the title of the Channel Reward instead of the cost.

Being the Channel Reward Cost an integer and the cost in the `config.json` file a string, this PR also casts the former to a string as well, while removing the `lower()` method as it becomes unnecessary.