### PR TITLE
Tighten substitution of cheer emotes

### DIFF
--- a/apps/processor/main.py
+++ b/apps/processor/main.py
@@ -28,7 +28,7 @@ from pedalboard.io import AudioFile
 from pydub import AudioSegment
 from rich.logging import RichHandler
 
-CHEER_REGEX: str = r"(?i)(cheer(?:whal)?|doodlecheer|biblethump|corgo|uni|showlove|party|seemsgood|pride|kappa|frankerz|heyguys|dansgame|elegiggle|trihard|kreygasm|4head|swiftrage|notlikethis|vohiyo|pjsalt|mrdestructoid|bday|ripcheer|shamrock|streamlabs|bitboss|muxy|anon)\d*"
+CHEER_REGEX: str = r"(?i)(cheer(?:whal)?|doodlecheer|biblethump|corgo|uni|showlove|party|seemsgood|pride|kappa|frankerz|heyguys|dansgame|elegiggle|trihard|kreygasm|4head|swiftrage|notlikethis|vohiyo|pjsalt|mrdestructoid|bday|ripcheer|shamrock|streamlabs|bitboss|muxy|anon)\d+"
 
 VOICE_EFFECTS: dict = {
     "reverb": Reverb(room_size=0.50),


### PR DESCRIPTION
Cheer emotes currently use `\d*` as part of the identifier, so they grab the cheer emote word (like cheer, party, or pride) with 0-any numbers afterwards.

This commit changes that to `\d+` so that the words themselves (such as pride) are not removed unless they're an emote (such as Pride1)